### PR TITLE
chore: release v0.1.0

### DIFF
--- a/crates/mdbookkit/CHANGELOG.md
+++ b/crates/mdbookkit/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/tonywu6/mdbookkit/releases/tag/mdbookkit-v0.1.0) - 2025-04-03
+
+### Other
+
+- [link-forever] fix(ci): page order in snapshots
+- [link-forever] fix: images in links
+- [docs] touch up crate docs
+- [docs] finalize book
+- [docs] socials
+- [link-forever] rewrite absolute paths to relative paths
+- [link-forever] check canonical URLs
+- [rustdoc-link] try to fix spurious RA progress reports
+- [ci] debug flaky test
+- [rustdoc-link] make RA probing less flaky?
+- [ci] setup actions
+- [docs] bundle fonts
+- [link-forever] improve fallback for new repos
+- [link-forever] docs
+- [link-forever] support images
+- link forever
+- link check
+- clean up
+- make into one crate + features


### PR DESCRIPTION



## 🤖 New release

* `mdbookkit`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/tonywu6/mdbookkit/releases/tag/mdbookkit-v0.1.0) - 2025-04-03

### Other

- [link-forever] fix(ci): page order in snapshots
- [link-forever] fix: images in links
- [docs] touch up crate docs
- [docs] finalize book
- [docs] socials
- [link-forever] rewrite absolute paths to relative paths
- [link-forever] check canonical URLs
- [rustdoc-link] try to fix spurious RA progress reports
- [ci] debug flaky test
- [rustdoc-link] make RA probing less flaky?
- [ci] setup actions
- [docs] bundle fonts
- [link-forever] improve fallback for new repos
- [link-forever] docs
- [link-forever] support images
- link forever
- link check
- clean up
- make into one crate + features
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).