### PR TITLE
fix(link-forever): generate slugs by actually emitting html

### DIFF
--- a/crates/mdbookkit/src/bin/link_forever/mod.rs
+++ b/crates/mdbookkit/src/bin/link_forever/mod.rs
@@ -11,7 +11,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use mdbook::utils::unique_id_from_content;
 use percent_encoding::percent_decode_str;
-use pulldown_cmark::{CowStr, Event, LinkType, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{html::push_html, CowStr, Event, LinkType, Options, Parser, Tag, TagEnd};
 use serde::Deserialize;
 use tap::{Pipe, Tap, TapFallible};
 use url::{form_urlencoded::Serializer as SearchParams, Url};
@@ -553,19 +553,7 @@ impl<'a> Page<'a> {
     where
         S: Iterator<Item = &'r Event<'r>>,
     {
-        fn unmark<'a>(event: &'a Event<'_>) -> &'a str {
-            match event {
-                Event::Text(text) => text,
-                Event::Code(text) => text,
-                Event::InlineMath(text) => text,
-                Event::DisplayMath(text) => text,
-                Event::Html(html) => html,
-                Event::InlineHtml(html) => html,
-                Event::FootnoteReference(href) => href,
-                _ => "",
-            }
-        }
-        let fragment = heading.map(unmark).collect::<String>();
+        let fragment = String::new().tap_mut(|s| push_html(s, heading.cloned()));
         let fragment = unique_id_from_content(&fragment, counter);
         self.fragments.insert(fragment);
     }

--- a/crates/mdbookkit/tests/link_forever.rs
+++ b/crates/mdbookkit/tests/link_forever.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 
 use anyhow::Result;
 use assert_cmd::{prelude::*, Command};
-use insta::with_settings;
 use log::LevelFilter;
 use predicates::prelude::*;
 use tap::Pipe;
@@ -61,15 +60,7 @@ fn test_snapshots() -> Result<()> {
                 .logging(false)
                 .build()
                 .to_report();
-            portable_snapshots!().test(|| {
-                with_settings!({
-                    filters => vec![
-                        (r"file:///[A-Z]:/", "file:///")
-                    ]
-                }, {
-                    insta::assert_snapshot!($snap, report)
-                })
-            })?;
+            portable_snapshots!().test(|| insta::assert_snapshot!($snap, report))?;
         };
     }
 

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.ignored.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.ignored.snap
@@ -4,43 +4,43 @@ expression: report
 ---
   info: link is ignored as it is not supported
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:45:13]
- 44 │ 
- 45 │ ## heading: <https://räksmörgås.josefsson.org/>
+    │ 
+    │ ## heading: <https://räksmörgås.josefsson.org/>
     ·             ───────────────────────────────────
- 46 │ 
- 47 │ # canonical urls to book
- 48 │ 
- 49 │ found: <https://example.org/book/tests/tests/ra-known-quirks>
- 50 │ 
- 51 │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
- 52 │ 
- 53 │ not found: <https://example.org/book/404>
- 54 │ 
- 55 │ ignored: <https://example.com/book/ra-known-quirks>
+    │ 
+    │ # canonical urls to book
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks>
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
+    │ 
+    │ not found: <https://example.org/book/404>
+    │ 
+    │ ignored: <https://example.com/book/ra-known-quirks>
     ·          ──────────────────────────────────────────
- 56 │ 
- 57 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
- 58 │ 
- 59 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
- 60 │ 
- 61 │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
- 62 │ 
- 63 │ # canonical urls to HEAD
- 64 │ 
- 65 │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
- 66 │ 
- 67 │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
- 68 │ 
- 69 │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
- 70 │ 
- 71 │ [fragment not found](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md#associated_items_on_primitive_types)
- 72 │ 
- 73 │ # image-in-link
- 74 │ 
- 75 │ [![crates.io](https://img.shields.io/crates/v/mdbookkit?style=flat-square)](https://crates.io/crates/mdbookkit)
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
+    │ 
+    │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
+    │ 
+    │ # canonical urls to HEAD
+    │ 
+    │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
+    │ 
+    │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
+    │ 
+    │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
+    │ 
+    │ [fragment not found](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md#associated_items_on_primitive_types)
+    │ 
+    │ # image-in-link
+    │ 
+    │ [![crates.io](https://img.shields.io/crates/v/mdbookkit?style=flat-square)](https://crates.io/crates/mdbookkit)
     · ────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- 76 │ 
- 77 │ [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)](https://commons.wikimedia.org/wiki/File:Macaca_nigra_self-portrait_large.jpg)
+    │ 
+    │ [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)](https://commons.wikimedia.org/wiki/File:Macaca_nigra_self-portrait_large.jpg)
     · ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- 78 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.ignored.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.ignored.snap
@@ -3,10 +3,13 @@ source: crates/mdbookkit/tests/link_forever.rs
 expression: report
 ---
   info: link is ignored as it is not supported
-    ╭─[crates/mdbookkit/tests/tests/link-forever.md:45:13]
+    ╭─[crates/mdbookkit/tests/tests/link-forever.md:47:13]
     │ 
     │ ## heading: <https://räksmörgås.josefsson.org/>
     ·             ───────────────────────────────────
+    │ 
+    │ ## heading: pub async fn foobar(rt: &mut [Foo]) -> [Bar]\<Self> <!-- omit from toc -->
+    ·                                          ─────     ─────
     │ 
     │ # canonical urls to book
     │ 

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-fragment.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-fragment.snap
@@ -3,7 +3,7 @@ source: crates/mdbookkit/tests/link_forever.rs
 expression: report
 ---
   warning: fragment does not exist in page
-    ╭─[crates/mdbookkit/tests/tests/link-forever.md:41:1]
+    ╭─[crates/mdbookkit/tests/tests/link-forever.md:43:1]
     │ 
     │ [associated items](../tests/ra-known-quirks.md#associated_items_on_primitive_types)
     · ─────────────────────────────────────────┬─────────────────────────────────────────
@@ -12,6 +12,8 @@ expression: report
     │ ## heading: $\sqrt{3x-1}+(1+x)^2$
     │ 
     │ ## heading: <https://räksmörgås.josefsson.org/>
+    │ 
+    │ ## heading: pub async fn foobar(rt: &mut [Foo]) -> [Bar]\<Self> <!-- omit from toc -->
     │ 
     │ # canonical urls to book
     │ 

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-fragment.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-fragment.snap
@@ -4,41 +4,41 @@ expression: report
 ---
   warning: fragment does not exist in page
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:41:1]
- 40 │ 
- 41 │ [associated items](../tests/ra-known-quirks.md#associated_items_on_primitive_types)
+    │ 
+    │ [associated items](../tests/ra-known-quirks.md#associated_items_on_primitive_types)
     · ─────────────────────────────────────────┬─────────────────────────────────────────
     ·                                          ╰── #associated_items_on_primitive_types not found in crates/mdbookkit/tests/tests/ra-known-quirks.md
- 42 │ 
- 43 │ ## heading: $\sqrt{3x-1}+(1+x)^2$
- 44 │ 
- 45 │ ## heading: <https://räksmörgås.josefsson.org/>
- 46 │ 
- 47 │ # canonical urls to book
- 48 │ 
- 49 │ found: <https://example.org/book/tests/tests/ra-known-quirks>
- 50 │ 
- 51 │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
- 52 │ 
- 53 │ not found: <https://example.org/book/404>
- 54 │ 
- 55 │ ignored: <https://example.com/book/ra-known-quirks>
- 56 │ 
- 57 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
- 58 │ 
- 59 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
- 60 │ 
- 61 │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
- 62 │ 
- 63 │ # canonical urls to HEAD
- 64 │ 
- 65 │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
- 66 │ 
- 67 │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
- 68 │ 
- 69 │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
- 70 │ 
- 71 │ [fragment not found](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md#associated_items_on_primitive_types)
+    │ 
+    │ ## heading: $\sqrt{3x-1}+(1+x)^2$
+    │ 
+    │ ## heading: <https://räksmörgås.josefsson.org/>
+    │ 
+    │ # canonical urls to book
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks>
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
+    │ 
+    │ not found: <https://example.org/book/404>
+    │ 
+    │ ignored: <https://example.com/book/ra-known-quirks>
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
+    │ 
+    │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
+    │ 
+    │ # canonical urls to HEAD
+    │ 
+    │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
+    │ 
+    │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
+    │ 
+    │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
+    │ 
+    │ [fragment not found](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md#associated_items_on_primitive_types)
     · ─────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────
     ·                                                                          ╰── #associated_items_on_primitive_types not found in crates/mdbookkit/tests/tests/ra-known-quirks.md
- 72 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-path.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-path.snap
@@ -4,53 +4,53 @@ expression: report
 ---
   warning: file does not exist at path
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:33:1]
- 32 │ 
- 33 │ [Cargo.lock](../../Cargo.lock)
+    │ 
+    │ [Cargo.lock](../../Cargo.lock)
     · ───────────────┬──────────────
     ·                ╰── file does not exist at path: crates/mdbookkit/Cargo.lock
- 34 │ 
- 35 │ [`//LICENSE-MIT.md`](//LICENSE-MIT.md)
- 36 │ 
- 37 │ ![shinjuku.jpg](shinjuku.jpg)
+    │ 
+    │ [`//LICENSE-MIT.md`](//LICENSE-MIT.md)
+    │ 
+    │ ![shinjuku.jpg](shinjuku.jpg)
     · ──────────────┬──────────────
     ·               ╰── file does not exist at path: crates/mdbookkit/tests/tests/shinjuku.jpg
- 38 │ 
- 39 │ # fragment not found
- 40 │ 
- 41 │ [associated items](../tests/ra-known-quirks.md#associated_items_on_primitive_types)
- 42 │ 
- 43 │ ## heading: $\sqrt{3x-1}+(1+x)^2$
- 44 │ 
- 45 │ ## heading: <https://räksmörgås.josefsson.org/>
- 46 │ 
- 47 │ # canonical urls to book
- 48 │ 
- 49 │ found: <https://example.org/book/tests/tests/ra-known-quirks>
- 50 │ 
- 51 │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
- 52 │ 
- 53 │ not found: <https://example.org/book/404>
+    │ 
+    │ # fragment not found
+    │ 
+    │ [associated items](../tests/ra-known-quirks.md#associated_items_on_primitive_types)
+    │ 
+    │ ## heading: $\sqrt{3x-1}+(1+x)^2$
+    │ 
+    │ ## heading: <https://räksmörgås.josefsson.org/>
+    │ 
+    │ # canonical urls to book
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks>
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
+    │ 
+    │ not found: <https://example.org/book/404>
     ·            ───────────────┬──────────────
     ·                           ╰── file does not exist at path: crates/mdbookkit/404.md
- 54 │ 
- 55 │ ignored: <https://example.com/book/ra-known-quirks>
- 56 │ 
- 57 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
- 58 │ 
- 59 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
- 60 │ 
- 61 │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
+    │ 
+    │ ignored: <https://example.com/book/ra-known-quirks>
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
+    │ 
+    │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
     ·                            ───────────────────────────┬───────────────────────────
     ·                                                       ╰── file does not exist at path: crates/mdbookkit/tests/tests/ra-known-quirks/index.md
- 62 │ 
- 63 │ # canonical urls to HEAD
- 64 │ 
- 65 │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
- 66 │ 
- 67 │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
- 68 │ 
- 69 │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
+    │ 
+    │ # canonical urls to HEAD
+    │ 
+    │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
+    │ 
+    │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
+    │ 
+    │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
     · ─────────────────────────────────────────────────┬─────────────────────────────────────────────────
     ·                                                  ╰── file does not exist at path: crates/mdbookkit/tests/tests/shinjuku.jpg
- 70 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-path.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.no-such-path.snap
@@ -3,7 +3,7 @@ source: crates/mdbookkit/tests/link_forever.rs
 expression: report
 ---
   warning: file does not exist at path
-    ╭─[crates/mdbookkit/tests/tests/link-forever.md:33:1]
+    ╭─[crates/mdbookkit/tests/tests/link-forever.md:35:1]
     │ 
     │ [Cargo.lock](../../Cargo.lock)
     · ───────────────┬──────────────
@@ -22,6 +22,8 @@ expression: report
     │ ## heading: $\sqrt{3x-1}+(1+x)^2$
     │ 
     │ ## heading: <https://räksmörgås.josefsson.org/>
+    │ 
+    │ ## heading: pub async fn foobar(rt: &mut [Foo]) -> [Bar]\<Self> <!-- omit from toc -->
     │ 
     │ # canonical urls to book
     │ 

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.not-checked-in.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.not-checked-in.snap
@@ -4,9 +4,9 @@ expression: report
 ---
   warning: path to a file outside source control
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:35:1]
- 34 │ 
- 35 │ [`//LICENSE-MIT.md`](//LICENSE-MIT.md)
+    │ 
+    │ [`//LICENSE-MIT.md`](//LICENSE-MIT.md)
     · ───────────────────┬──────────────────
     ·                    ╰── path to a file outside source control: file:///LICENSE-MIT.md
- 36 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.not-checked-in.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.not-checked-in.snap
@@ -3,7 +3,7 @@ source: crates/mdbookkit/tests/link_forever.rs
 expression: report
 ---
   warning: path to a file outside source control
-    ╭─[crates/mdbookkit/tests/tests/link-forever.md:35:1]
+    ╭─[crates/mdbookkit/tests/tests/link-forever.md:37:1]
     │ 
     │ [`//LICENSE-MIT.md`](//LICENSE-MIT.md)
     · ───────────────────┬──────────────────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.permalink.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.permalink.snap
@@ -20,7 +20,7 @@ expression: report
     ·                    ╰── link: https://github.com/lorem/ipsum/tree/dolor/LICENSE-APACHE.md
     │ 
     ╰────
-    ╭─[crates/mdbookkit/tests/tests/link-forever.md:65:1]
+    ╭─[crates/mdbookkit/tests/tests/link-forever.md:69:1]
     │ 
     │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
     · ───────────────────────────────────┬───────────────────────────────────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.permalink.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.permalink.snap
@@ -4,26 +4,26 @@ expression: report
 ---
   info: link converted to permalink
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:3:1]
-  2 │ 
-  3 │ [Cargo.toml](../../../../Cargo.toml)
+    │ 
+    │ [Cargo.toml](../../../../Cargo.toml)
     · ──────────────────┬─────────────────
     ·                   ╰── link: https://github.com/lorem/ipsum/tree/dolor/Cargo.toml
-  4 │ 
-  5 │ ![error reporting](../../../../docs/src/rustdoc-link/media/error-reporting.png)
+    │ 
+    │ ![error reporting](../../../../docs/src/rustdoc-link/media/error-reporting.png)
     · ───────────────────────────────────────┬───────────────────────────────────────
     ·                                        ╰── link: https://github.com/lorem/ipsum/tree/dolor/docs/src/rustdoc-link/media/error-reporting.png
-  6 │ 
-  7 │ # absolute paths
-  8 │ 
-  9 │ [LICENSE-APACHE.md](/LICENSE-APACHE.md)
+    │ 
+    │ # absolute paths
+    │ 
+    │ [LICENSE-APACHE.md](/LICENSE-APACHE.md)
     · ───────────────────┬───────────────────
     ·                    ╰── link: https://github.com/lorem/ipsum/tree/dolor/LICENSE-APACHE.md
- 10 │ 
+    │ 
     ╰────
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:65:1]
- 64 │ 
- 65 │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
+    │ 
+    │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
     · ───────────────────────────────────┬───────────────────────────────────
     ·                                    ╰── link: https://github.com/lorem/ipsum/tree/dolor/LICENSE-APACHE.md
- 66 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.published.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.published.snap
@@ -4,35 +4,35 @@ expression: report
 ---
   info: link to book page or file
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:15:1]
- 14 │ 
- 15 │ [Known quirks](./ra-known-quirks.md)
+    │ 
+    │ [Known quirks](./ra-known-quirks.md)
     · ──────────────────┬─────────────────
     ·                   ╰── file: crates/mdbookkit/tests/tests/ra-known-quirks.md
- 16 │ 
- 17 │ [link_forever.rs](../link_forever.rs)
+    │ 
+    │ [link_forever.rs](../link_forever.rs)
     · ──────────────────┬──────────────────
     ·                   ╰── file: crates/mdbookkit/tests/link_forever.rs
- 18 │ 
- 19 │ ![selfie](Macaca_nigra_self-portrait_large.jpg)
+    │ 
+    │ ![selfie](Macaca_nigra_self-portrait_large.jpg)
     · ───────────────────────┬───────────────────────
     ·                        ╰── file: crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg
- 20 │ 
- 21 │ # fragments
- 22 │ 
- 23 │ [Fragments](./link-forever.md#fragments)
+    │ 
+    │ # fragments
+    │ 
+    │ [Fragments](./link-forever.md#fragments)
     · ────────────────────┬───────────────────
     ·                     ╰── file: crates/mdbookkit/tests/tests/link-forever.md
- 24 │ 
- 25 │ [Heading 1](./link-forever.md#heading-sqrt3x-11x2)
+    │ 
+    │ [Heading 1](./link-forever.md#heading-sqrt3x-11x2)
     · ─────────────────────────┬────────────────────────
     ·                          ╰── file: crates/mdbookkit/tests/tests/link-forever.md
- 26 │ 
- 27 │ [Heading 2](./link-forever.md#heading-httpsräksmörgåsjosefssonorg)
+    │ 
+    │ [Heading 2](./link-forever.md#heading-httpsräksmörgåsjosefssonorg)
     · ─────────────────────────────────┬────────────────────────────────
     ·                                  ╰── file: crates/mdbookkit/tests/tests/link-forever.md
- 28 │ 
- 29 │ [macro_export](./ra-known-quirks.md#macro_export)
+    │ 
+    │ [macro_export](./ra-known-quirks.md#macro_export)
     · ────────────────────────┬────────────────────────
     ·                         ╰── file: crates/mdbookkit/tests/tests/ra-known-quirks.md
- 30 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.published.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.published.snap
@@ -31,6 +31,10 @@ expression: report
     · ─────────────────────────────────┬────────────────────────────────
     ·                                  ╰── file: crates/mdbookkit/tests/tests/link-forever.md
     │ 
+    │ [foobar](#heading-pub-async-fn-foobarrt-mut-foo---barself)
+    · ─────────────────────────────┬────────────────────────────
+    ·                              ╰── file: crates/mdbookkit/tests/tests/link-forever.md
+    │ 
     │ [macro_export](./ra-known-quirks.md#macro_export)
     · ────────────────────────┬────────────────────────
     ·                         ╰── file: crates/mdbookkit/tests/tests/ra-known-quirks.md

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.rewritten.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.rewritten.snap
@@ -4,64 +4,64 @@ expression: report
 ---
   info: link to book page or file rewritten as path
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:11:1]
- 10 │ 
- 11 │ [link-forever.md](/crates/mdbookkit/tests/tests/link-forever.md#absolute-paths)
+    │ 
+    │ [link-forever.md](/crates/mdbookkit/tests/tests/link-forever.md#absolute-paths)
     · ───────────────────────────────────────┬───────────────────────────────────────
     ·                                        ╰─┤ file: crates/mdbookkit/tests/tests/link-forever.md
     ·                                          │ link: #absolute-paths
- 12 │ 
+    │ 
     ╰────
     ╭─[crates/mdbookkit/tests/tests/link-forever.md:49:8]
- 48 │ 
- 49 │ found: <https://example.org/book/tests/tests/ra-known-quirks>
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks>
     ·        ───────────────────────────┬──────────────────────────
     ·                                   ╰─┤ file: crates/mdbookkit/tests/tests/ra-known-quirks.md
     ·                                     │ link: ra-known-quirks.md
- 50 │ 
- 51 │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
+    │ 
+    │ found: <https://example.org/book/tests/tests/ra-known-quirks.html>
     ·        ─────────────────────────────┬─────────────────────────────
     ·                                     ╰─┤ file: crates/mdbookkit/tests/tests/ra-known-quirks.md
     ·                                       │ link: ra-known-quirks.md
- 52 │ 
- 53 │ not found: <https://example.org/book/404>
- 54 │ 
- 55 │ ignored: <https://example.com/book/ra-known-quirks>
- 56 │ 
- 57 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
+    │ 
+    │ not found: <https://example.org/book/404>
+    │ 
+    │ ignored: <https://example.com/book/ra-known-quirks>
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash/>
     ·                        ───────────────────────────┬──────────────────────────
     ·                                                   ╰─┤ file: crates/mdbookkit/tests/tests/trailing-slash/index.md
     ·                                                     │ link: trailing-slash/index.md
- 58 │ 
- 59 │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
+    │ 
+    │ trailing slash, found: <https://example.org/book/tests/tests/trailing-slash>
     ·                        ──────────────────────────┬──────────────────────────
     ·                                                  ╰─┤ file: crates/mdbookkit/tests/tests/trailing-slash/index.md
     ·                                                    │ link: trailing-slash/index.md
- 60 │ 
- 61 │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
- 62 │ 
- 63 │ # canonical urls to HEAD
- 64 │ 
- 65 │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
- 66 │ 
- 67 │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
+    │ 
+    │ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks/>
+    │ 
+    │ # canonical urls to HEAD
+    │ 
+    │ [permalink](https://github.com/lorem/ipsum/tree/HEAD/LICENSE-APACHE.md)
+    │ 
+    │ [published](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md)
     · ──────────────────────────────────────────────────┬──────────────────────────────────────────────────
     ·                                                   ╰─┤ file: crates/mdbookkit/tests/tests/ra-known-quirks.md
     ·                                                     │ link: ra-known-quirks.md
- 68 │ 
- 69 │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
- 70 │ 
- 71 │ [fragment not found](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md#associated_items_on_primitive_types)
- 72 │ 
- 73 │ # image-in-link
- 74 │ 
- 75 │ [![crates.io](https://img.shields.io/crates/v/mdbookkit?style=flat-square)](https://crates.io/crates/mdbookkit)
- 76 │ 
- 77 │ [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)](https://commons.wikimedia.org/wiki/File:Macaca_nigra_self-portrait_large.jpg)
+    │ 
+    │ [file not found](https://github.com/lorem/ipsum/raw/HEAD/crates/mdbookkit/tests/tests/shinjuku.jpg)
+    │ 
+    │ [fragment not found](https://github.com/lorem/ipsum/tree/HEAD/crates/mdbookkit/tests/tests/ra-known-quirks.md#associated_items_on_primitive_types)
+    │ 
+    │ # image-in-link
+    │ 
+    │ [![crates.io](https://img.shields.io/crates/v/mdbookkit?style=flat-square)](https://crates.io/crates/mdbookkit)
+    │ 
+    │ [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)](https://commons.wikimedia.org/wiki/File:Macaca_nigra_self-portrait_large.jpg)
     ·  ──────────────────────────────────────┬──────────────────────────────────────
     ·                                        ╰─┤ file: crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg
     ·                                          │ link: Macaca_nigra_self-portrait_large.jpg
- 78 │ 
- 79 │ [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg) <br> Self-portrait of a female Macaca nigra in North Sulawesi (2011)](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)
+    │ 
+    │ [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg) <br> Self-portrait of a female Macaca nigra in North Sulawesi (2011)](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)
     · ────────────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────┬
     ·                                                                                                             │                                                                                                           ╰─┤ file: crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg
     ·                                                                                                             │                                                                                                             │ link: Macaca_nigra_self-portrait_large.jpg

--- a/crates/mdbookkit/tests/snaps/link_forever/_stderr.rewritten.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/_stderr.rewritten.snap
@@ -11,7 +11,7 @@ expression: report
     ·                                          │ link: #absolute-paths
     │ 
     ╰────
-    ╭─[crates/mdbookkit/tests/tests/link-forever.md:49:8]
+    ╭─[crates/mdbookkit/tests/tests/link-forever.md:53:8]
     │ 
     │ found: <https://example.org/book/tests/tests/ra-known-quirks>
     ·        ───────────────────────────┬──────────────────────────
@@ -67,4 +67,5 @@ expression: report
     ·                                                                                                             │                                                                                                             │ link: Macaca_nigra_self-portrait_large.jpg
     ·                                                                                                             ╰─┤ file: crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg
     ·                                                                                                               │ link: Macaca_nigra_self-portrait_large.jpg
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/link_forever/link-forever.snap
+++ b/crates/mdbookkit/tests/snaps/link_forever/link-forever.snap
@@ -30,6 +30,8 @@ expression: output
 
 [Heading 2](./link-forever.md#heading-httpsräksmörgåsjosefssonorg)
 
+[foobar](#heading-pub-async-fn-foobarrt-mut-foo---barself)
+
 [macro_export](./ra-known-quirks.md#macro_export)
 
 # file not found
@@ -47,6 +49,8 @@ expression: output
 ## heading: $\sqrt{3x-1}+(1+x)^2$
 
 ## heading: <https://räksmörgås.josefsson.org/>
+
+## heading: pub async fn foobar(rt: &mut [Foo]) -> [Bar]\<Self> <!-- omit from toc -->
 
 # canonical urls to book
 
@@ -81,3 +85,6 @@ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks
 [![selfie](Macaca_nigra_self-portrait_large.jpg)](https://commons.wikimedia.org/wiki/File:Macaca_nigra_self-portrait_large.jpg)
 
 [![selfie](Macaca_nigra_self-portrait_large.jpg) <br> Self-portrait of a female Macaca nigra in North Sulawesi (2011)](Macaca_nigra_self-portrait_large.jpg)
+
+[Foo]: https://example.org
+[Bar]: https://example.org

--- a/crates/mdbookkit/tests/snaps/rustdoc_link/getting-started.stderr.snap
+++ b/crates/mdbookkit/tests/snaps/rustdoc_link/getting-started.stderr.snap
@@ -1,17 +1,16 @@
 ---
 source: crates/mdbookkit/tests/rustdoc_link.rs
-assertion_line: 44
 expression: report
 ---
   info: successfully resolved all links
     ╭─[getting-started:52:6]
- 51 │ 
- 52 │ Like [`std::thread::spawn`], [`tokio::task::spawn`] returns a
+    │ 
+    │ Like [`std::thread::spawn`], [`tokio::task::spawn`] returns a
     ·      ───────────┬──────────  ───────────┬──────────
     ·                 │                       ╰── https://docs.rs/tokio/1.44.1/tokio/task/spawn/fn.spawn.html
     ·                 ╰── https://doc.rust-lang.org/stable/std/thread/fn.spawn.html
- 53 │ [`JoinHandle`][tokio::task::JoinHandle] struct.
+    │ [`JoinHandle`][tokio::task::JoinHandle] struct.
     · ───────────────────┬───────────────────
     ·                    ╰── https://docs.rs/tokio/1.44.1/tokio/runtime/task/join/struct.JoinHandle.html
- 54 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/rustdoc_link/index.stderr.snap
+++ b/crates/mdbookkit/tests/snaps/rustdoc_link/index.stderr.snap
@@ -4,18 +4,18 @@ expression: report
 ---
   info: successfully resolved all links
     ╭─[index:25:5]
- 24 │ 
- 25 │ The [`option`][std::option] and [`result`][std::result] modules define optional and
+    │ 
+    │ The [`option`][std::option] and [`result`][std::result] modules define optional and
     ·     ───────────┬───────────     ───────────┬───────────
     ·                │                           ╰── https://doc.rust-lang.org/stable/core/result/index.html
     ·                ╰── https://doc.rust-lang.org/stable/core/option/index.html
- 26 │ error-handling types, [`Option<T>`] and [`Result<T, E>`]. The [`iter`][std::iter] module
+    │ error-handling types, [`Option<T>`] and [`Result<T, E>`]. The [`iter`][std::iter] module
     ·                       ──────┬──────     ────────┬───────      ─────────┬─────────
     ·                             │                   │                      ╰── https://doc.rust-lang.org/stable/core/iter/index.html
     ·                             │                   ╰── https://doc.rust-lang.org/stable/core/result/enum.Result.html
     ·                             ╰── https://doc.rust-lang.org/stable/core/option/enum.Option.html
- 27 │ defines Rust's iterator trait, [`Iterator`], which works with the `for` loop to access
+    │ defines Rust's iterator trait, [`Iterator`], which works with the `for` loop to access
     ·                                ──────┬─────
     ·                                      ╰── https://doc.rust-lang.org/stable/core/iter/traits/iterator/trait.Iterator.html
- 28 │ collections. [^1]
+    │ collections. [^1]
     ╰────

--- a/crates/mdbookkit/tests/snaps/rustdoc_link/known-issues.stderr.snap
+++ b/crates/mdbookkit/tests/snaps/rustdoc_link/known-issues.stderr.snap
@@ -4,43 +4,43 @@ expression: report
 ---
   info: successfully resolved all links
     ╭─[known-issues:45:3]
- 44 │ 
- 45 │ - [~~`panic!`~~], and many other `std` macros
+    │ 
+    │ - [~~`panic!`~~], and many other `std` macros
     ·   ───────┬──────
     ·          ╰── https://doc.rust-lang.org/stable/std/macros/macro.panic.html
- 46 │   - The correct link is
- 47 │     [https://doc.rust-lang.org/stable/std~~/macros~~/macro.panic.html][panic]
- 48 │ - [~~`serde_json::json!`~~]
+    │   - The correct link is
+    │     [https://doc.rust-lang.org/stable/std~~/macros~~/macro.panic.html][panic]
+    │ - [~~`serde_json::json!`~~]
     ·   ────────────┬────────────
     ·               ╰── https://docs.rs/serde_json/1.0.140/serde_json/macros/macro.json.html
- 49 │   - The correct link is
- 50 │     [https://docs.rs/serde_json/1.0.140/serde_json~~/macros~~/macro.json.html][serde_json::json]
- 51 │ 
- 52 │ Attribute macros generate links that use `macro.<macro_name>.html`, but rustdoc actually
- 53 │ generates `attr.<macro_name>.html`. For example:
- 54 │ 
- 55 │ - [~~`tokio::main!`~~]
+    │   - The correct link is
+    │     [https://docs.rs/serde_json/1.0.140/serde_json~~/macros~~/macro.json.html][serde_json::json]
+    │ 
+    │ Attribute macros generate links that use `macro.<macro_name>.html`, but rustdoc actually
+    │ generates `attr.<macro_name>.html`. For example:
+    │ 
+    │ - [~~`tokio::main!`~~]
     ·   ──────────┬─────────
     ·             ╰── https://docs.rs/tokio-macros/2.5.0/tokio_macros/macro.main.html
- 56 │   - The correct link is
- 57 │     [https://docs.rs/tokio-macros/2.5.0/tokio_macros/~~macro~~attr.main.html][tokio::main]
- 58 │ 
- 59 │ ### Trait items
- 60 │ 
- 61 │ Rust allows methods to have the same name if they are from different traits, and types
- 62 │ can implement the same trait multiple times if the trait is generic. All such methods
- 63 │ will appear on the same page for the type.
- 64 │ 
- 65 │ rustdoc will number the generated URL fragments so that they remain unique within the
- 66 │ HTML document. rust-analyzer does not yet have the ability to do so.
- 67 │ 
- 68 │ For example, these are the same links:
- 69 │ 
- 70 │ - [`<std::net::IpAddr as From<std::net::Ipv4Addr>>::from`]
+    │   - The correct link is
+    │     [https://docs.rs/tokio-macros/2.5.0/tokio_macros/~~macro~~attr.main.html][tokio::main]
+    │ 
+    │ ### Trait items
+    │ 
+    │ Rust allows methods to have the same name if they are from different traits, and types
+    │ can implement the same trait multiple times if the trait is generic. All such methods
+    │ will appear on the same page for the type.
+    │ 
+    │ rustdoc will number the generated URL fragments so that they remain unique within the
+    │ HTML document. rust-analyzer does not yet have the ability to do so.
+    │ 
+    │ For example, these are the same links:
+    │ 
+    │ - [`<std::net::IpAddr as From<std::net::Ipv4Addr>>::from`]
     ·   ────────────────────────────┬───────────────────────────
     ·                               ╰── https://doc.rust-lang.org/stable/core/net/ip_addr/enum.IpAddr.html#method.from
- 71 │ - [`<std::net::IpAddr as From<std::net::Ipv6Addr>>::from`]
+    │ - [`<std::net::IpAddr as From<std::net::Ipv6Addr>>::from`]
     ·   ────────────────────────────┬───────────────────────────
     ·                               ╰── https://doc.rust-lang.org/stable/core/net/ip_addr/enum.IpAddr.html#method.from
- 72 │ 
+    │ 
     ╰────

--- a/crates/mdbookkit/tests/snaps/rustdoc_link/ra-known-quirks.stderr.snap
+++ b/crates/mdbookkit/tests/snaps/rustdoc_link/ra-known-quirks.stderr.snap
@@ -4,41 +4,41 @@ expression: report
 ---
   warning: failed to resolve some links
     ╭─[ra-known-quirks:3:3]
-  2 │ 
-  3 │ - [u8]
+    │ 
+    │ - [u8]
     ·   ──┬─
     ·     ╰── https://doc.rust-lang.org/nightly/core/primitive.u8.html
-  4 │ - [u32]
+    │ - [u32]
     ·   ──┬──
     ·     ╰── https://doc.rust-lang.org/nightly/core/primitive.u32.html
-  5 │ - [f64]
+    │ - [f64]
     ·   ──┬──
     ·     ╰── https://doc.rust-lang.org/nightly/core/primitive.f64.html
-  6 │ - [char]
+    │ - [char]
     ·   ───┬──
     ·      ╰── https://doc.rust-lang.org/nightly/core/primitive.char.html
-  7 │ - [str]
+    │ - [str]
     ·   ──┬──
     ·     ╰── https://doc.rust-lang.org/nightly/core/primitive.str.html
-  8 │ 
-  9 │ # associated items on primitive types
- 10 │ 
- 11 │ - [str::parse]
+    │ 
+    │ # associated items on primitive types
+    │ 
+    │ - [str::parse]
     ·   ──────┬─────
     ·         ╰── failed to resolve link for "str::parse"
- 12 │ - [f64::MIN_POSITIVE]
+    │ - [f64::MIN_POSITIVE]
     ·   ─────────┬─────────
     ·            ╰── failed to resolve link for "f64::MIN_POSITIVE"
- 13 │ 
- 14 │ # macro_export
- 15 │ 
- 16 │ - [std::vec!]
+    │ 
+    │ # macro_export
+    │ 
+    │ - [std::vec!]
     ·   ─────┬─────
     ·        ╰── https://doc.rust-lang.org/stable/alloc/macros/macro.vec.html
- 17 │ - [std::format!]
+    │ - [std::format!]
     ·   ───────┬──────
     ·          ╰── https://doc.rust-lang.org/stable/alloc/macros/macro.format.html
- 18 │ - [tokio::main!]
+    │ - [tokio::main!]
     ·   ───────┬──────
     ·          ╰── https://docs.rs/tokio-macros/2.5.0/tokio_macros/macro.main.html
     ╰────

--- a/crates/mdbookkit/tests/snaps/rustdoc_link/supported-syntax.stderr.snap
+++ b/crates/mdbookkit/tests/snaps/rustdoc_link/supported-syntax.stderr.snap
@@ -4,282 +4,282 @@ expression: report
 ---
   info: successfully resolved all links
      ╭─[supported-syntax:46:10]
-  45 │ >
-  46 │ > Module [`alloc`][std::alloc] — Memory allocation APIs.
+     │ >
+     │ > Module [`alloc`][std::alloc] — Memory allocation APIs.
      ·          ──────────┬──────────
      ·                    ╰── https://doc.rust-lang.org/stable/std/alloc/index.html
-  47 │ >
-  48 │ > ```md
-  49 │ > Every [`Option`] is either [`Some`][Option::Some][^1] and contains a value, or
-  50 │ > [`None`][Option::None][^1], and does not.
-  51 │ > ```
-  52 │ >
-  53 │ > Every [`Option`] is either [`Some`][Option::Some][^1] and contains a value, or
+     │ >
+     │ > ```md
+     │ > Every [`Option`] is either [`Some`][Option::Some][^1] and contains a value, or
+     │ > [`None`][Option::None][^1], and does not.
+     │ > ```
+     │ >
+     │ > Every [`Option`] is either [`Some`][Option::Some][^1] and contains a value, or
      ·         ─────┬────           ───────────┬──────────
      ·              │                          ╰── https://doc.rust-lang.org/stable/core/option/enum.Option.html#variant.Some
      ·              ╰── https://doc.rust-lang.org/stable/core/option/enum.Option.html
-  54 │ > [`None`][Option::None][^1], and does not.
+     │ > [`None`][Option::None][^1], and does not.
      ·   ───────────┬──────────
      ·              ╰── https://doc.rust-lang.org/stable/core/option/enum.Option.html#variant.None
-  55 │ >
-  56 │ > ```md
-  57 │ > [`Ipv4Addr::LOCALHOST`][core::net::Ipv4Addr::LOCALHOST] — An IPv4 address with the
-  58 │ > address pointing to localhost: `127.0.0.1`.
-  59 │ > ```
-  60 │ >
-  61 │ > [`Ipv4Addr::LOCALHOST`][core::net::Ipv4Addr::LOCALHOST] — An IPv4 address with the
+     │ >
+     │ > ```md
+     │ > [`Ipv4Addr::LOCALHOST`][core::net::Ipv4Addr::LOCALHOST] — An IPv4 address with the
+     │ > address pointing to localhost: `127.0.0.1`.
+     │ > ```
+     │ >
+     │ > [`Ipv4Addr::LOCALHOST`][core::net::Ipv4Addr::LOCALHOST] — An IPv4 address with the
      ·   ───────────────────────────┬───────────────────────────
      ·                              ╰── https://doc.rust-lang.org/stable/core/net/ip_addr/struct.Ipv4Addr.html#associatedconstant.LOCALHOST
-  62 │ > address pointing to localhost: `127.0.0.1`.
-  63 │ 
-  64 │ ## Generic parameters
-  65 │ 
-  66 │ Types can contain generic parameters. This is _compatible_ with rustdoc.
-  67 │ 
-  68 │ > ```md
-  69 │ > [`Vec<T>`] — A heap-allocated _vector_ that is resizable at runtime.
-  70 │ > ```
-  71 │ >
-  72 │ > [`Vec<T>`] — A heap-allocated _vector_ that is resizable at runtime.
+     │ > address pointing to localhost: `127.0.0.1`.
+     │ 
+     │ ## Generic parameters
+     │ 
+     │ Types can contain generic parameters. This is _compatible_ with rustdoc.
+     │ 
+     │ > ```md
+     │ > [`Vec<T>`] — A heap-allocated _vector_ that is resizable at runtime.
+     │ > ```
+     │ >
+     │ > [`Vec<T>`] — A heap-allocated _vector_ that is resizable at runtime.
      ·   ─────┬────
      ·        ╰── https://doc.rust-lang.org/stable/alloc/vec/struct.Vec.html
-  73 │ >
-  74 │ > ```md
-  75 │ > | Phantom type                                       | variance of `T`   |
-  76 │ > | :------------------------------------------------- | :---------------- |
-  77 │ > | [`&'a mut T`][std::marker::PhantomData<&'a mut T>] | **in**variant     |
-  78 │ > | [`fn(T)`][std::marker::PhantomData<fn(T)>]         | **contra**variant |
-  79 │ > ```
-  80 │ >
-  81 │ > | Phantom type                                       | variance of `T`   |
-  82 │ > | :------------------------------------------------- | :---------------- |
-  83 │ > | [`&'a mut T`][std::marker::PhantomData<&'a mut T>] | **in**variant     |
+     │ >
+     │ > ```md
+     │ > | Phantom type                                       | variance of `T`   |
+     │ > | :------------------------------------------------- | :---------------- |
+     │ > | [`&'a mut T`][std::marker::PhantomData<&'a mut T>] | **in**variant     |
+     │ > | [`fn(T)`][std::marker::PhantomData<fn(T)>]         | **contra**variant |
+     │ > ```
+     │ >
+     │ > | Phantom type                                       | variance of `T`   |
+     │ > | :------------------------------------------------- | :---------------- |
+     │ > | [`&'a mut T`][std::marker::PhantomData<&'a mut T>] | **in**variant     |
      ·     ─────────────────────────┬────────────────────────
      ·                              ╰── https://doc.rust-lang.org/stable/core/marker/struct.PhantomData.html
-  84 │ > | [`fn(T)`][std::marker::PhantomData<fn(T)>]         | **contra**variant |
+     │ > | [`fn(T)`][std::marker::PhantomData<fn(T)>]         | **contra**variant |
      ·     ─────────────────────┬────────────────────
      ·                          ╰── https://doc.rust-lang.org/stable/core/marker/struct.PhantomData.html
-  85 │ 
-  86 │ This includes if you use turbofish:
-  87 │ 
-  88 │ > ```md
-  89 │ > `collect()` is one of the few times you’ll see the syntax affectionately known as the
-  90 │ > "turbofish", for example: [`Iterator::collect::<Vec<i32>>()`].
-  91 │ > ```
-  92 │ >
-  93 │ > `collect()` is one of the few times you’ll see the syntax affectionately known as the
-  94 │ > "turbofish", for example: [`Iterator::collect::<Vec<i32>>()`].
+     │ 
+     │ This includes if you use turbofish:
+     │ 
+     │ > ```md
+     │ > `collect()` is one of the few times you’ll see the syntax affectionately known as the
+     │ > "turbofish", for example: [`Iterator::collect::<Vec<i32>>()`].
+     │ > ```
+     │ >
+     │ > `collect()` is one of the few times you’ll see the syntax affectionately known as the
+     │ > "turbofish", for example: [`Iterator::collect::<Vec<i32>>()`].
      ·                             ─────────────────┬─────────────────
      ·                                              ╰── https://doc.rust-lang.org/stable/core/iter/traits/iterator/trait.Iterator.html#method.collect
-  95 │ 
-  96 │ ## Functions and macros
-  97 │ 
-  98 │ To indicate that an item is a function, add `()` after the function name. To indicate
-  99 │ that an item is a macro, add `!` after the macro name, optionally followed by `()`,
- 100 │ `[]`, or `{}`. This is _compatible_ with rustdoc.
- 101 │ 
- 102 │ Note that there cannot be arguments within `()`, `[]`, or `{}`.
- 103 │ 
- 104 │ > ```md
- 105 │ > [`vec!`][std::vec!][^2] is different from [`vec`][std::vec], and don't accidentally
- 106 │ > use [`format()`][std::fmt::format()] in place of [`format!()`][std::format!()][^2]!
- 107 │ > ```
- 108 │ >
- 109 │ > [`vec!`][std::vec!][^2] is different from [`vec`][std::vec], and don't accidentally
+     │ 
+     │ ## Functions and macros
+     │ 
+     │ To indicate that an item is a function, add `()` after the function name. To indicate
+     │ that an item is a macro, add `!` after the macro name, optionally followed by `()`,
+     │ `[]`, or `{}`. This is _compatible_ with rustdoc.
+     │ 
+     │ Note that there cannot be arguments within `()`, `[]`, or `{}`.
+     │ 
+     │ > ```md
+     │ > [`vec!`][std::vec!][^2] is different from [`vec`][std::vec], and don't accidentally
+     │ > use [`format()`][std::fmt::format()] in place of [`format!()`][std::format!()][^2]!
+     │ > ```
+     │ >
+     │ > [`vec!`][std::vec!][^2] is different from [`vec`][std::vec], and don't accidentally
      ·   ─────────┬─────────                       ────────┬────────
      ·            │                                        ╰── https://doc.rust-lang.org/stable/alloc/vec/index.html
      ·            ╰── https://doc.rust-lang.org/stable/alloc/macros/macro.vec.html
- 110 │ > use [`format()`][std::fmt::format()] in place of [`format!()`][std::format!()][^2]!
+     │ > use [`format()`][std::fmt::format()] in place of [`format!()`][std::format!()][^2]!
      ·       ────────────────┬───────────────             ──────────────┬──────────────
      ·                       │                                          ╰── https://doc.rust-lang.org/stable/alloc/macros/macro.format.html
      ·                       ╰── https://doc.rust-lang.org/stable/alloc/fmt/fn.format.html
- 111 │ 
- 112 │ The macro syntax works for attribute and derive macros as well (even though this is not
- 113 │ how they are invoked).
- 114 │ 
- 115 │ > ```md
- 116 │ > There is a [derive macro][serde::Serialize!] to generate implementations of the
- 117 │ > [`Serialize`][serde::Serialize] trait.
- 118 │ > ```
- 119 │ >
- 120 │ > There is a [derive macro][serde::Serialize!] to generate implementations of the
+     │ 
+     │ The macro syntax works for attribute and derive macros as well (even though this is not
+     │ how they are invoked).
+     │ 
+     │ > ```md
+     │ > There is a [derive macro][serde::Serialize!] to generate implementations of the
+     │ > [`Serialize`][serde::Serialize] trait.
+     │ > ```
+     │ >
+     │ > There is a [derive macro][serde::Serialize!] to generate implementations of the
      ·              ────────────────┬────────────────
      ·                              ╰── https://docs.rs/serde_derive/1.0.219/serde_derive/derive.Serialize.html
- 121 │ > [`Serialize`][serde::Serialize] trait.
+     │ > [`Serialize`][serde::Serialize] trait.
      ·   ───────────────┬───────────────
      ·                  ╰── https://docs.rs/serde/1.0.219/serde/ser/trait.Serialize.html
- 122 │ 
- 123 │ ## Implementors and fully qualified syntax
- 124 │ 
- 125 │ Trait implementors may supply additional documentation about their implementations. To
- 126 │ link to implemented items instead of the traits themselves, use fully qualified paths,
- 127 │ including `<... as Trait>` if necessary. This is a _new feature_ that rustdoc does not
- 128 │ currently support.
- 129 │ 
- 130 │ > ```md
- 131 │ > [`Result<T, E>`] implements [`IntoIterator`]; its
- 132 │ > [**`into_iter()`**][Result::<(), ()>::into_iter] returns an iterator that yields one
- 133 │ > value if the result is [`Result::Ok`], otherwise none.
- 134 │ >
- 135 │ > [`Vec<T>`] also implements [`IntoIterator`]; a vector cannot be used after you call
- 136 │ > [**`into_iter()`**][<Vec<()> as IntoIterator>::into_iter].
- 137 │ > ```
- 138 │ >
- 139 │ > [`Result<T, E>`] implements [`IntoIterator`]; its
+     │ 
+     │ ## Implementors and fully qualified syntax
+     │ 
+     │ Trait implementors may supply additional documentation about their implementations. To
+     │ link to implemented items instead of the traits themselves, use fully qualified paths,
+     │ including `<... as Trait>` if necessary. This is a _new feature_ that rustdoc does not
+     │ currently support.
+     │ 
+     │ > ```md
+     │ > [`Result<T, E>`] implements [`IntoIterator`]; its
+     │ > [**`into_iter()`**][Result::<(), ()>::into_iter] returns an iterator that yields one
+     │ > value if the result is [`Result::Ok`], otherwise none.
+     │ >
+     │ > [`Vec<T>`] also implements [`IntoIterator`]; a vector cannot be used after you call
+     │ > [**`into_iter()`**][<Vec<()> as IntoIterator>::into_iter].
+     │ > ```
+     │ >
+     │ > [`Result<T, E>`] implements [`IntoIterator`]; its
      ·   ────────┬───────            ────────┬───────
      ·           │                           ╰── https://doc.rust-lang.org/stable/core/iter/traits/collect/trait.IntoIterator.html
      ·           ╰── https://doc.rust-lang.org/stable/core/result/enum.Result.html
- 140 │ > [**`into_iter()`**][Result::<(), ()>::into_iter] returns an iterator that yields one
+     │ > [**`into_iter()`**][Result::<(), ()>::into_iter] returns an iterator that yields one
      ·   ────────────────────────┬───────────────────────
      ·                           ╰── https://doc.rust-lang.org/stable/core/result/enum.Result.html#method.into_iter
- 141 │ > value if the result is [`Result::Ok`], otherwise none.
+     │ > value if the result is [`Result::Ok`], otherwise none.
      ·                          ───────┬──────
      ·                                 ╰── https://doc.rust-lang.org/stable/core/result/enum.Result.html#variant.Ok
- 142 │ >
- 143 │ > [`Vec<T>`] also implements [`IntoIterator`]; a vector cannot be used after you call
+     │ >
+     │ > [`Vec<T>`] also implements [`IntoIterator`]; a vector cannot be used after you call
      ·   ─────┬────                 ────────┬───────
      ·        │                             ╰── https://doc.rust-lang.org/stable/core/iter/traits/collect/trait.IntoIterator.html
      ·        ╰── https://doc.rust-lang.org/stable/alloc/vec/struct.Vec.html
- 144 │ > [**`into_iter()`**][<Vec<()> as IntoIterator>::into_iter].
+     │ > [**`into_iter()`**][<Vec<()> as IntoIterator>::into_iter].
      ·   ────────────────────────────┬────────────────────────────
      ·                               ╰── https://doc.rust-lang.org/stable/alloc/vec/struct.Vec.html#method.into_iter
- 145 │ 
- 146 │ > [!NOTE]
- 147 │ >
- 148 │ > If your type has generic parameters, you must supply concrete types for them for
- 149 │ > rust-analyzer to be able to locate an implementation. That is, `Result<T, E>` won't
- 150 │ > work, but `Result<(), ()>` will (unless there happen to be types `T` and `E` literally
- 151 │ > in scope).
- 152 │ 
- 153 │ ## Disambiguators
- 154 │ 
- 155 │ rustdoc's [disambiguator syntax][disambiguator] `prefix@name` is **accepted but
- 156 │ ignored**:
- 157 │ 
- 158 │ > ```md
- 159 │ > [`std::vec`], [`mod@std::vec`], and [`macro@std::vec`] all link to the `vec` _module_.
- 160 │ > ```
- 161 │ >
- 162 │ > [`std::vec`], [`mod@std::vec`], and [`macro@std::vec`] all link to the `vec` _module_.
+     │ 
+     │ > [!NOTE]
+     │ >
+     │ > If your type has generic parameters, you must supply concrete types for them for
+     │ > rust-analyzer to be able to locate an implementation. That is, `Result<T, E>` won't
+     │ > work, but `Result<(), ()>` will (unless there happen to be types `T` and `E` literally
+     │ > in scope).
+     │ 
+     │ ## Disambiguators
+     │ 
+     │ rustdoc's [disambiguator syntax][disambiguator] `prefix@name` is **accepted but
+     │ ignored**:
+     │ 
+     │ > ```md
+     │ > [`std::vec`], [`mod@std::vec`], and [`macro@std::vec`] all link to the `vec` _module_.
+     │ > ```
+     │ >
+     │ > [`std::vec`], [`mod@std::vec`], and [`macro@std::vec`] all link to the `vec` _module_.
      ·   ──────┬─────  ────────┬───────      ─────────┬────────
      ·         │               │                      ╰── https://doc.rust-lang.org/stable/alloc/vec/index.html
      ·         │               ╰── https://doc.rust-lang.org/stable/alloc/vec/index.html
      ·         ╰── https://doc.rust-lang.org/stable/alloc/vec/index.html
- 163 │ 
- 164 │ This is largely okay because currently, duplicate names in Rust are allowed only if they
- 165 │ correspond to items in different [namespaces], for example, between macros and modules,
- 166 │ and between struct fields and methods — this is mostly covered by the function and macro
- 167 │ syntax, described [above](#functions-and-macros).
- 168 │ 
- 169 │ If you encounter items that must be disambiguated using rustdoc's disambiguator syntax,
- 170 │ other than [the "special types" listed below](#special-types), please [file an
- 171 │ issue][gh-issues]!
- 172 │ 
- 173 │ ## Special types
- 174 │ 
- 175 │ > [!WARNING]
- 176 │ 
- 177 │ There is **no support** on types whose syntax is not a path; they are currently not
- 178 │ parsed at all:
- 179 │ 
- 180 │ > references `&T`, slices `[T]`, arrays `[T; N]`, tuples `(T1, T2)`, pointers like
- 181 │ > `*const T`, trait objects like `dyn Any`, and the never type `!`
- 182 │ 
- 183 │ Note that such types can still be used as generic params, just not as standalone types.
- 184 │ 
- 185 │ ## Struct fields
- 186 │ 
- 187 │ > [!WARNING]
- 188 │ 
- 189 │ Linking to struct fields is **not supported** yet. This is **incompatible** with
- 190 │ rustdoc.
- 191 │ 
- 192 │ ## Markdown link syntax
- 193 │ 
- 194 │ All Markdown link formats supported by rustdoc are supported:
- 195 │ 
- 196 │ Linking with URL inlined:
- 197 │ 
- 198 │ > ```md
- 199 │ > [The Option type](std::option::Option)
- 200 │ > ```
- 201 │ >
- 202 │ > [The Option type](std::option::Option)
+     │ 
+     │ This is largely okay because currently, duplicate names in Rust are allowed only if they
+     │ correspond to items in different [namespaces], for example, between macros and modules,
+     │ and between struct fields and methods — this is mostly covered by the function and macro
+     │ syntax, described [above](#functions-and-macros).
+     │ 
+     │ If you encounter items that must be disambiguated using rustdoc's disambiguator syntax,
+     │ other than [the "special types" listed below](#special-types), please [file an
+     │ issue][gh-issues]!
+     │ 
+     │ ## Special types
+     │ 
+     │ > [!WARNING]
+     │ 
+     │ There is **no support** on types whose syntax is not a path; they are currently not
+     │ parsed at all:
+     │ 
+     │ > references `&T`, slices `[T]`, arrays `[T; N]`, tuples `(T1, T2)`, pointers like
+     │ > `*const T`, trait objects like `dyn Any`, and the never type `!`
+     │ 
+     │ Note that such types can still be used as generic params, just not as standalone types.
+     │ 
+     │ ## Struct fields
+     │ 
+     │ > [!WARNING]
+     │ 
+     │ Linking to struct fields is **not supported** yet. This is **incompatible** with
+     │ rustdoc.
+     │ 
+     │ ## Markdown link syntax
+     │ 
+     │ All Markdown link formats supported by rustdoc are supported:
+     │ 
+     │ Linking with URL inlined:
+     │ 
+     │ > ```md
+     │ > [The Option type](std::option::Option)
+     │ > ```
+     │ >
+     │ > [The Option type](std::option::Option)
      ·   ───────────────────┬──────────────────
      ·                      ╰── https://doc.rust-lang.org/stable/core/option/enum.Option.html
- 203 │ 
- 204 │ Linking with reusable references:
- 205 │ 
- 206 │ > ```md
- 207 │ > [The Option type][option-type]
- 208 │ >
- 209 │ > [option-type]: std::option::Option
- 210 │ > ```
- 211 │ >
- 212 │ > [The Option type][option-type]
+     │ 
+     │ Linking with reusable references:
+     │ 
+     │ > ```md
+     │ > [The Option type][option-type]
+     │ >
+     │ > [option-type]: std::option::Option
+     │ > ```
+     │ >
+     │ > [The Option type][option-type]
      ·   ───────────────┬──────────────
      ·                  ╰── https://doc.rust-lang.org/stable/core/option/enum.Option.html
- 213 │ >
- 214 │ > [option-type]: std::option::Option
- 215 │ 
- 216 │ Reference-style links `[text][id]` without a corresponding `[id]: name` part will be
- 217 │ treated the same as inline-style links `[text](id)`:
- 218 │ 
- 219 │ > ```md
- 220 │ > [The Option type][std::option::Option]
- 221 │ > ```
- 222 │ >
- 223 │ > [The Option type][std::option::Option]
+     │ >
+     │ > [option-type]: std::option::Option
+     │ 
+     │ Reference-style links `[text][id]` without a corresponding `[id]: name` part will be
+     │ treated the same as inline-style links `[text](id)`:
+     │ 
+     │ > ```md
+     │ > [The Option type][std::option::Option]
+     │ > ```
+     │ >
+     │ > [The Option type][std::option::Option]
      ·   ───────────────────┬──────────────────
      ·                      ╰── https://doc.rust-lang.org/stable/core/option/enum.Option.html
- 224 │ 
- 225 │ Shortcuts are supported, and can contain inline markups:
- 226 │ 
- 227 │ > ```md
- 228 │ > You can create a [`Vec`] with [**`Vec::new`**], or by using the [_`vec!`_][^2] macro.
- 229 │ > ```
- 230 │ >
- 231 │ > You can create a [`Vec`] with [**`Vec::new`**], or by using the [_`vec!`_][^2] macro.
+     │ 
+     │ Shortcuts are supported, and can contain inline markups:
+     │ 
+     │ > ```md
+     │ > You can create a [`Vec`] with [**`Vec::new`**], or by using the [_`vec!`_][^2] macro.
+     │ > ```
+     │ >
+     │ > You can create a [`Vec`] with [**`Vec::new`**], or by using the [_`vec!`_][^2] macro.
      ·                    ───┬───      ────────┬───────                  ─────┬────
      ·                       │                 │                              ╰── https://doc.rust-lang.org/stable/alloc/macros/macro.vec.html
      ·                       │                 ╰── https://doc.rust-lang.org/stable/alloc/vec/struct.Vec.html#method.new
      ·                       ╰── https://doc.rust-lang.org/stable/alloc/vec/struct.Vec.html
- 232 │ 
- 233 │ (The items must still be resolvable; in this case `Vec` and `vec!` come from the
- 234 │ prelude.)
- 235 │ 
- 236 │ ## Linking to page sections
- 237 │ 
- 238 │ To link to a known section on a page, use a URL fragment, just like a normal link. This
- 239 │ is _compatible_ with rustdoc.
- 240 │ 
- 241 │ <!-- prettier-ignore-start -->
- 242 │ 
- 243 │ > ```md
- 244 │ > [When Should You Use Which Collection?][std::collections#when-should-you-use-which-collection]
- 245 │ > ```
- 246 │ >
- 247 │ > [When Should You Use Which Collection?][std::collections#when-should-you-use-which-collection]
+     │ 
+     │ (The items must still be resolvable; in this case `Vec` and `vec!` come from the
+     │ prelude.)
+     │ 
+     │ ## Linking to page sections
+     │ 
+     │ To link to a known section on a page, use a URL fragment, just like a normal link. This
+     │ is _compatible_ with rustdoc.
+     │ 
+     │ <!-- prettier-ignore-start -->
+     │ 
+     │ > ```md
+     │ > [When Should You Use Which Collection?][std::collections#when-should-you-use-which-collection]
+     │ > ```
+     │ >
+     │ > [When Should You Use Which Collection?][std::collections#when-should-you-use-which-collection]
      ·   ───────────────────────────────────────────────┬──────────────────────────────────────────────
      ·                                                  ╰── https://doc.rust-lang.org/stable/std/collections/index.html
- 248 │ 
- 249 │ <!-- prettier-ignore-end -->
- 250 │ 
- 251 │ [^1]:
- 252 │     rust-analyzer's ability to generate links for enum variants like `Option::Some` was
- 253 │     improved only somewhat recently: before
- 254 │     [#19246](https://github.com/rust-lang/rust-analyzer/pull/19246), links for variants
- 255 │     and associated items may only point to the types themselves. If linking to such
- 256 │     items doesn't seem to work for you, be sure to upgrade to a newer rust-analyzer
- 257 │     first!
- 258 │ 
- 259 │ [^2]:
- 260 │     As of rust-analyzer <ra-version>(version)</ra-version>, links generated for macros
- 261 │     don't always work. Examples include [`std::format!`] (seen above) and
+     │ 
+     │ <!-- prettier-ignore-end -->
+     │ 
+     │ [^1]:
+     │     rust-analyzer's ability to generate links for enum variants like `Option::Some` was
+     │     improved only somewhat recently: before
+     │     [#19246](https://github.com/rust-lang/rust-analyzer/pull/19246), links for variants
+     │     and associated items may only point to the types themselves. If linking to such
+     │     items doesn't seem to work for you, be sure to upgrade to a newer rust-analyzer
+     │     first!
+     │ 
+     │ [^2]:
+     │     As of rust-analyzer <ra-version>(version)</ra-version>, links generated for macros
+     │     don't always work. Examples include [`std::format!`] (seen above) and
      ·                                         ────────┬───────
      ·                                                 ╰── https://doc.rust-lang.org/stable/alloc/macros/macro.format.html
- 262 │     [`tokio::main!`]. For more info, see [Known issues](known-issues.md#macros).
+     │     [`tokio::main!`]. For more info, see [Known issues](known-issues.md#macros).
      ·     ────────┬───────
      ·             ╰── https://docs.rs/tokio-macros/2.5.0/tokio_macros/macro.main.html
- 263 │ 
+     │ 
      ╰────

--- a/crates/mdbookkit/tests/tests/link-forever.md
+++ b/crates/mdbookkit/tests/tests/link-forever.md
@@ -26,6 +26,8 @@
 
 [Heading 2](./link-forever.md#heading-httpsräksmörgåsjosefssonorg)
 
+[foobar](#heading-pub-async-fn-foobarrt-mut-foo---barself)
+
 [macro_export](./ra-known-quirks.md#macro_export)
 
 # file not found
@@ -43,6 +45,8 @@
 ## heading: $\sqrt{3x-1}+(1+x)^2$
 
 ## heading: <https://räksmörgås.josefsson.org/>
+
+## heading: pub async fn foobar(rt: &mut [Foo]) -> [Bar]\<Self> <!-- omit from toc -->
 
 # canonical urls to book
 
@@ -77,3 +81,6 @@ trailing slash, not found: <https://example.org/book/tests/tests/ra-known-quirks
 [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)](https://commons.wikimedia.org/wiki/File:Macaca_nigra_self-portrait_large.jpg)
 
 [![selfie](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg) <br> Self-portrait of a female Macaca nigra in North Sulawesi (2011)](/crates/mdbookkit/tests/tests/Macaca_nigra_self-portrait_large.jpg)
+
+[Foo]: https://example.org
+[Bar]: https://example.org

--- a/deno.lock
+++ b/deno.lock
@@ -3,7 +3,10 @@
   "specifiers": {
     "jsr:@std/encoding@*": "1.0.8",
     "jsr:@std/path@*": "1.0.8",
+    "npm:@types/node@*": "22.12.0",
     "npm:esbuild@*": "0.25.1",
+    "npm:esbuild@0.25": "0.25.1",
+    "npm:esbuild@0.25.2": "0.25.2",
     "npm:esbuild@~0.25.1": "0.25.1",
     "npm:prettier@*": "3.5.3",
     "npm:prettier@^3.5.3": "3.5.3",
@@ -59,77 +62,152 @@
     "@esbuild/aix-ppc64@0.25.1": {
       "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ=="
     },
+    "@esbuild/aix-ppc64@0.25.2": {
+      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag=="
+    },
     "@esbuild/android-arm64@0.25.1": {
       "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA=="
+    },
+    "@esbuild/android-arm64@0.25.2": {
+      "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w=="
     },
     "@esbuild/android-arm@0.25.1": {
       "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q=="
     },
+    "@esbuild/android-arm@0.25.2": {
+      "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA=="
+    },
     "@esbuild/android-x64@0.25.1": {
       "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw=="
+    },
+    "@esbuild/android-x64@0.25.2": {
+      "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg=="
     },
     "@esbuild/darwin-arm64@0.25.1": {
       "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ=="
     },
+    "@esbuild/darwin-arm64@0.25.2": {
+      "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA=="
+    },
     "@esbuild/darwin-x64@0.25.1": {
       "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA=="
+    },
+    "@esbuild/darwin-x64@0.25.2": {
+      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA=="
     },
     "@esbuild/freebsd-arm64@0.25.1": {
       "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A=="
     },
+    "@esbuild/freebsd-arm64@0.25.2": {
+      "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w=="
+    },
     "@esbuild/freebsd-x64@0.25.1": {
       "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww=="
+    },
+    "@esbuild/freebsd-x64@0.25.2": {
+      "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ=="
     },
     "@esbuild/linux-arm64@0.25.1": {
       "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ=="
     },
+    "@esbuild/linux-arm64@0.25.2": {
+      "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g=="
+    },
     "@esbuild/linux-arm@0.25.1": {
       "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ=="
+    },
+    "@esbuild/linux-arm@0.25.2": {
+      "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g=="
     },
     "@esbuild/linux-ia32@0.25.1": {
       "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ=="
     },
+    "@esbuild/linux-ia32@0.25.2": {
+      "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ=="
+    },
     "@esbuild/linux-loong64@0.25.1": {
       "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg=="
+    },
+    "@esbuild/linux-loong64@0.25.2": {
+      "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w=="
     },
     "@esbuild/linux-mips64el@0.25.1": {
       "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg=="
     },
+    "@esbuild/linux-mips64el@0.25.2": {
+      "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q=="
+    },
     "@esbuild/linux-ppc64@0.25.1": {
       "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg=="
+    },
+    "@esbuild/linux-ppc64@0.25.2": {
+      "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g=="
     },
     "@esbuild/linux-riscv64@0.25.1": {
       "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ=="
     },
+    "@esbuild/linux-riscv64@0.25.2": {
+      "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw=="
+    },
     "@esbuild/linux-s390x@0.25.1": {
       "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ=="
+    },
+    "@esbuild/linux-s390x@0.25.2": {
+      "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q=="
     },
     "@esbuild/linux-x64@0.25.1": {
       "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA=="
     },
+    "@esbuild/linux-x64@0.25.2": {
+      "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg=="
+    },
     "@esbuild/netbsd-arm64@0.25.1": {
       "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g=="
+    },
+    "@esbuild/netbsd-arm64@0.25.2": {
+      "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw=="
     },
     "@esbuild/netbsd-x64@0.25.1": {
       "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA=="
     },
+    "@esbuild/netbsd-x64@0.25.2": {
+      "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg=="
+    },
     "@esbuild/openbsd-arm64@0.25.1": {
       "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg=="
+    },
+    "@esbuild/openbsd-arm64@0.25.2": {
+      "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg=="
     },
     "@esbuild/openbsd-x64@0.25.1": {
       "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw=="
     },
+    "@esbuild/openbsd-x64@0.25.2": {
+      "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw=="
+    },
     "@esbuild/sunos-x64@0.25.1": {
       "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg=="
+    },
+    "@esbuild/sunos-x64@0.25.2": {
+      "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA=="
     },
     "@esbuild/win32-arm64@0.25.1": {
       "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ=="
     },
+    "@esbuild/win32-arm64@0.25.2": {
+      "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q=="
+    },
     "@esbuild/win32-ia32@0.25.1": {
       "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A=="
     },
+    "@esbuild/win32-ia32@0.25.2": {
+      "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg=="
+    },
     "@esbuild/win32-x64@0.25.1": {
       "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg=="
+    },
+    "@esbuild/win32-x64@0.25.2": {
+      "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="
     },
     "@keyv/serialize@1.0.3": {
       "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
@@ -152,6 +230,12 @@
       "dependencies": [
         "@nodelib/fs.scandir",
         "fastq"
+      ]
+    },
+    "@types/node@22.12.0": {
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "dependencies": [
+        "undici-types"
       ]
     },
     "ajv@8.17.1": {
@@ -271,31 +355,61 @@
     "esbuild@0.25.1": {
       "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
       "dependencies": [
-        "@esbuild/aix-ppc64",
-        "@esbuild/android-arm",
-        "@esbuild/android-arm64",
-        "@esbuild/android-x64",
-        "@esbuild/darwin-arm64",
-        "@esbuild/darwin-x64",
-        "@esbuild/freebsd-arm64",
-        "@esbuild/freebsd-x64",
-        "@esbuild/linux-arm",
-        "@esbuild/linux-arm64",
-        "@esbuild/linux-ia32",
-        "@esbuild/linux-loong64",
-        "@esbuild/linux-mips64el",
-        "@esbuild/linux-ppc64",
-        "@esbuild/linux-riscv64",
-        "@esbuild/linux-s390x",
-        "@esbuild/linux-x64",
-        "@esbuild/netbsd-arm64",
-        "@esbuild/netbsd-x64",
-        "@esbuild/openbsd-arm64",
-        "@esbuild/openbsd-x64",
-        "@esbuild/sunos-x64",
-        "@esbuild/win32-arm64",
-        "@esbuild/win32-ia32",
-        "@esbuild/win32-x64"
+        "@esbuild/aix-ppc64@0.25.1",
+        "@esbuild/android-arm64@0.25.1",
+        "@esbuild/android-arm@0.25.1",
+        "@esbuild/android-x64@0.25.1",
+        "@esbuild/darwin-arm64@0.25.1",
+        "@esbuild/darwin-x64@0.25.1",
+        "@esbuild/freebsd-arm64@0.25.1",
+        "@esbuild/freebsd-x64@0.25.1",
+        "@esbuild/linux-arm64@0.25.1",
+        "@esbuild/linux-arm@0.25.1",
+        "@esbuild/linux-ia32@0.25.1",
+        "@esbuild/linux-loong64@0.25.1",
+        "@esbuild/linux-mips64el@0.25.1",
+        "@esbuild/linux-ppc64@0.25.1",
+        "@esbuild/linux-riscv64@0.25.1",
+        "@esbuild/linux-s390x@0.25.1",
+        "@esbuild/linux-x64@0.25.1",
+        "@esbuild/netbsd-arm64@0.25.1",
+        "@esbuild/netbsd-x64@0.25.1",
+        "@esbuild/openbsd-arm64@0.25.1",
+        "@esbuild/openbsd-x64@0.25.1",
+        "@esbuild/sunos-x64@0.25.1",
+        "@esbuild/win32-arm64@0.25.1",
+        "@esbuild/win32-ia32@0.25.1",
+        "@esbuild/win32-x64@0.25.1"
+      ]
+    },
+    "esbuild@0.25.2": {
+      "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
+      "dependencies": [
+        "@esbuild/aix-ppc64@0.25.2",
+        "@esbuild/android-arm64@0.25.2",
+        "@esbuild/android-arm@0.25.2",
+        "@esbuild/android-x64@0.25.2",
+        "@esbuild/darwin-arm64@0.25.2",
+        "@esbuild/darwin-x64@0.25.2",
+        "@esbuild/freebsd-arm64@0.25.2",
+        "@esbuild/freebsd-x64@0.25.2",
+        "@esbuild/linux-arm64@0.25.2",
+        "@esbuild/linux-arm@0.25.2",
+        "@esbuild/linux-ia32@0.25.2",
+        "@esbuild/linux-loong64@0.25.2",
+        "@esbuild/linux-mips64el@0.25.2",
+        "@esbuild/linux-ppc64@0.25.2",
+        "@esbuild/linux-riscv64@0.25.2",
+        "@esbuild/linux-s390x@0.25.2",
+        "@esbuild/linux-x64@0.25.2",
+        "@esbuild/netbsd-arm64@0.25.2",
+        "@esbuild/netbsd-x64@0.25.2",
+        "@esbuild/openbsd-arm64@0.25.2",
+        "@esbuild/openbsd-x64@0.25.2",
+        "@esbuild/sunos-x64@0.25.2",
+        "@esbuild/win32-arm64@0.25.2",
+        "@esbuild/win32-ia32@0.25.2",
+        "@esbuild/win32-x64@0.25.2"
       ]
     },
     "fast-deep-equal@3.1.3": {
@@ -710,6 +824,9 @@
       "dependencies": [
         "is-number"
       ]
+    },
+    "undici-types@6.20.0": {
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "util-deprecate@1.0.2": {
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="

--- a/docs/app/build/build.ts
+++ b/docs/app/build/build.ts
@@ -1,6 +1,6 @@
 import { encodeHex } from "jsr:@std/encoding/hex";
 import * as pathlib from "jsr:@std/path";
-import * as esbuild from "npm:esbuild";
+import * as esbuild from "npm:esbuild@0.25.2";
 
 const relpath = (path: string) => new URL(path, import.meta.url).pathname;
 

--- a/utils/testing/src/lib.rs
+++ b/utils/testing/src/lib.rs
@@ -57,8 +57,16 @@ impl PortableSnapshots {
             .fold(snapshot_dir, |dir, path| dir.join(path));
 
         let result = insta::Settings::clone_current()
-            .tap_mut(|settings| settings.set_snapshot_path(path))
-            .tap_mut(|settings| settings.set_prepend_module_to_snapshot(false))
+            .tap_mut(|s| s.set_snapshot_path(path))
+            .tap_mut(|s| s.set_prepend_module_to_snapshot(false))
+            .tap_mut(|s| {
+                s.set_filters(vec![
+                    (r"file:///[A-Z]:/", "file:///"), // windows paths
+                    (r"(?m)^(\s+)\d{1} ", "$1  "),    // miette line numbers
+                    (r"(?m)^(\s+)\d{2} ", "$1   "),
+                    (r"(?m)^(\s+)\d{3} ", "$1    "),
+                ])
+            })
             .bind(cb);
 
         Ok(result)


### PR DESCRIPTION
Previously slugs are extracted by filtering `pulldown_cmark` events, which is different from how mdbook does it, leading to discrepancies in edge cases.