### PR TITLE
chore: release v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Quality-of-life plugins for your [mdBook] project!
 
 [![link to documentation](https://img.shields.io/github/actions/workflow/status/tonywu6/mdbookkit/docs.yml?event=release&style=flat-square&label=docs)](https://docs.tonywu.dev/mdbookkit/)
-[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/mdbookkit?style=flat-square)](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/LICENSE-APACHE.md)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/mdbookkit?style=flat-square)](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/LICENSE-APACHE.md)
 
 ## mdbook-rustdoc-links
 
@@ -43,8 +43,8 @@ cargo install mdbook-permalinks
 
 ## License
 
-This project is released under the [Apache 2.0 License](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/LICENSE-APACHE.md) and the
-[MIT License](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/LICENSE-MIT.md).
+This project is released under the [Apache 2.0 License](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/LICENSE-APACHE.md) and the
+[MIT License](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/LICENSE-MIT.md).
 
 <!-- prettier-ignore-start -->
 [mdBook]: https://rust-lang.github.io/mdBook/

--- a/crates/mdbook-permalinks/README.md
+++ b/crates/mdbook-permalinks/README.md
@@ -23,7 +23,7 @@ Here is a link to the project's [Cargo.toml](/Cargo.toml).
 
 <figure class="fig-text">
 
-Here is a link to the project's [Cargo.toml](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/Cargo.toml).
+Here is a link to the project's [Cargo.toml](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/Cargo.toml).
 
 </figure>
 
@@ -63,8 +63,8 @@ Link rot happens all the time. The preprocessor will tell you about it.
 
 ## License
 
-This project is released under the [Apache 2.0 License](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/LICENSE-APACHE.md) and the
-[MIT License](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/LICENSE-MIT.md).
+This project is released under the [Apache 2.0 License](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/LICENSE-APACHE.md) and the
+[MIT License](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/LICENSE-MIT.md).
 
 <!-- prettier-ignore-start -->
 [mdBook]: https://rust-lang.github.io/mdBook/

--- a/crates/mdbook-rustdoc-links/README.md
+++ b/crates/mdbook-rustdoc-links/README.md
@@ -87,8 +87,8 @@ Happy linking!
 
 ## License
 
-This project is released under the [Apache 2.0 License](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/LICENSE-APACHE.md) and the
-[MIT License](https://github.com/tonywu6/mdbookkit/tree/88431989183b48e8c052751b39f547e8824ea677/LICENSE-MIT.md).
+This project is released under the [Apache 2.0 License](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/LICENSE-APACHE.md) and the
+[MIT License](https://github.com/tonywu6/mdbookkit/tree/7d3b6af50a2ba1aa4235c6a11396c7d77d939815/LICENSE-MIT.md).
 
 [^1]: Text adapted from [<cite>A Tour of The Rust Standard Library</cite>][tour]
 


### PR DESCRIPTION



## 🤖 New release

* `mdbookkit`: 2.0.1 -> 3.0.0
* `mdbook-permalinks`: 2.0.1 -> 3.0.0
* `mdbook-rustdoc-links`: 2.0.1 -> 3.0.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `mdbook-permalinks`

<blockquote>

## 3.0.0

[Code changes from v2.0.1 to v3.0.0](https://github.com/tonywu6/mdbookkit/compare/mdbook-permalinks-v2.0.1..mdbook-permalinks-v3.0.0)

### Breaking changes

- [The `book-url` option has been removed.](#v3.0.0-book-url)

### <!-- 0 --> Added

- **More Git forges:** The preprocessor now has built-in support for repositories hosted on Tangled (<https://tangled.org>) and Codeberg (<https://codeberg.org>), in addition to GitHub.

  If your repo is on one of these sites, simply configuring the [`output.html.git-repository-url`](https://docs.tonywu.dev/mdbookkit/permalinks/how-to/remote-url#setting-git-repository-url) option or [setting up `git remote`](https://docs.tonywu.dev/mdbookkit/permalinks/how-to/remote-url#configuring-git-remote) will suffice, and the use of the [`repo-url-template`](https://docs.tonywu.dev/mdbookkit/permalinks/reference/configuration#repo-url-template) option is no longer necessary.

- **HTML support:** The preprocessor can now process [hyperlinks found in HTML markups](https://docs.tonywu.dev/mdbookkit/permalinks/getting-started#html-links).

  For example, you can now use [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img) and [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video) elements to include images and videos in your book, and the preprocessor will convert the URLs to permalinks.

- **Better local previewing:** An _experimental_ "dev mode," in which the preprocessor renders links that can be viewed locally (as opposed to regular permalinks). This should provide a better editing experience when e.g. using `mdbook serve`. To learn more, see the [local development guide](https://docs.tonywu.dev/mdbookkit/permalinks/how-to/local-development).

- The `repo-url-template` option supports [additional customization](https://docs.tonywu.dev/mdbookkit/permalinks/reference/configuration#repo-url-templateparams--repo-url-templatetemplate).

### <!-- 1 --> Fixed

- The preprocessor now performs stricter validation, especially for links to book pages. It is now also aware of symlinks.

  As such, broken links that were previously accepted as valid may now result in warnings. You can read more about the special cases in the [reference](https://docs.tonywu.dev/mdbookkit/permalinks/reference/behaviors).

### <!-- 2 --> Changed

- **<span id="v3.0.0-book-url">\[BREAKING\]</span> The `book-url` option has been removed:** Instead, simply use mdBook's `output.html.site-url` option and specify the same value.

  The `book-url` option previously enabled the preprocessor to validate hard-coded links to your book's website. Such validation is still supported, but the preprocessor can now reuse the value of `output.html.site-url`. For more info, see the relevant section in the [URL checking guide](https://docs.tonywu.dev/mdbookkit/permalinks/how-to/hardcoded-links#checking-urls-to-your-book).

- When running in an empty Git repository (one without any commit), the preprocessor will no longer fail with an error, but will instead emit a warning.

- The preprocessor now provides improved diagnostic messages for broken links, which should better explain how the link was determined to be incorrect.
</blockquote>

## `mdbook-rustdoc-links`

<blockquote>

## 3.0.0

[Code changes from v2.0.1 to v3.0.0](https://github.com/tonywu6/mdbookkit/compare/mdbook-rustdoc-links-v2.0.1...mdbook-rustdoc-links-v3.0.0)

The preprocessor has been rewritten to **no longer depend on rust-analyzer!** Instead, it utilizes `cargo doc` directly.

- The preprocessor now requires **only a _stable_ Rust toolchain** (nightly not required).

  If you had previously setup your CI pipelines to run the preprocessor, you can safely remove rust-analyzer related instructions from your workflows.

- The preprocessor now parses and generates links **exactly the same way that [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) does.**

  For example, you can now both use the [disambiguator syntax](https://docs.tonywu.dev/mdbookkit/rustdoc-links/writing-links#namespaces-and-disambiguators) and link to struct fields, where the previous version [did not support them](https://github.com/tonywu6/mdbookkit/blob/mdbook-rustdoc-links-v2.0.1/docs/src/rustdoc-links/supported-syntax.md#unsupported-syntax). There were also [subtle cases](https://github.com/tonywu6/mdbookkit/blob/mdbook-rustdoc-links-v2.0.1/docs/src/rustdoc-links/known-issues.md#incorrectunresolvable-links) in which the preprocessor would generate incorrect links.

  > In other words, if `cargo doc` can successfully resolve an intra-doc link in a doc comment, then the preprocessor is now expected to also resolve the same link in mdBook (so long as the item is ["in scope"](https://docs.tonywu.dev/mdbookkit/rustdoc-links/naming-items)). If you notice any discrepancies, please don't hesitate to [file an issue](https://github.com/tonywu6/mdbookkit/issues)!

- The preprocessor also inherits [rustdoc's **incredibly helpful diagnostics**](https://doc.rust-lang.org/stable/rustdoc/lints.html).

- The preprocessor now has the **same performance and caching capability as `cargo doc`**.

  The preprocessor no longer has to spawn `rust-analyzer` every time `mdbook serve` refreshes (which was noticeably slow and resource-hungry even for moderately sized projects), or use a bespoke caching mechanism.

- Because the preprocessor essentially automates running `cargo doc`, when authoring documentation, you can choose to [**preview the local version of your crate docs**](https://docs.tonywu.dev/mdbookkit/rustdoc-links/how-to/local-development), instead of what's on docs.rs. You can even choose to bundle your crate docs with your book, if you are looking to [self-host](https://docs.tonywu.dev/mdbookkit/rustdoc-links/how-to/self-hosting-cargo-docs) them.

To learn more about the new version, feel free to peruse the updated [tutorials](https://docs.tonywu.dev/mdbookkit/rustdoc-links/getting-started) and [how-to guides](https://docs.tonywu.dev/mdbookkit/rustdoc-links/how-to)!

### Breaking changes

- The following options have been removed.

  - `rust-analyzer`
  - `rust-analyzer-timeout`
  - `cache-dir`
  - `cargo-features` (superseded by a new [build config format](https://docs.tonywu.dev/mdbookkit/rustdoc-links/how-to/conditional-compilation#specifying-features))

- The preprocessor now **by default only processes items from packages in your workspace** (as opposed to e.g. items from dependencies).

  You can document more packages, including dependencies, by configuring the [`build.packages`](https://docs.tonywu.dev/mdbookkit/rustdoc-links/how-to/package-selection) option. This was previously not configurable, and rust-analyzer would need to index every package used, even if the majority of them you didn't need in your documentation.

- The ["standalone usage"](https://github.com/tonywu6/mdbookkit/blob/mdbook-rustdoc-links-v2.0.1/docs/src/rustdoc-links/standalone-usage.md) mode has been removed.

- The "link report" feature is now controlled by a [dedicated environment variable](https://docs.tonywu.dev/mdbookkit/rustdoc-links/reference/environment-variables#mdbookkit_link_report).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).